### PR TITLE
Fix capitalization to build on linux

### DIFF
--- a/cmake/External/gflags.cmake
+++ b/cmake/External/gflags.cmake
@@ -2,7 +2,7 @@ if (NOT __GFLAGS_INCLUDED) # guard against multiple includes
   set(__GFLAGS_INCLUDED TRUE)
 
   # use the system-wide gflags if present
-  find_package(GFlags)
+  find_package(GFLAGS)
   if (GFLAGS_FOUND)
     set(GFLAGS_EXTERNAL FALSE)
   else()


### PR DESCRIPTION
CMake behaves a little different on Linux. If you write `find_package(GFlags)`, the `GFLAGS_FOUND` flag will still not be set because CMake will only set `GFlags_FOUND` (note capitalization).