### PR TITLE
Move Y construction to outer loop

### DIFF
--- a/src/solve_lq_game.cpp
+++ b/src/solve_lq_game.cpp
@@ -155,15 +155,15 @@ std::vector<Strategy> SolveLQGame(
           S_block = BiZi * lin.Bs[jj];
         }
 
-        // Set appropriate blocks of Y.
-        Y.block(cumulative_udim_row, 0, dynamics.UDim(ii), dynamics.XDim()) =
-            BiZi * lin.A;
-        Y.col(dynamics.XDim()).segment(cumulative_udim_row, dynamics.UDim(ii)) =
-            lin.Bs[ii].transpose() * zetas[ii];
-
         // Increment cumulative_udim_col.
         cumulative_udim_col += dynamics.UDim(jj);
       }
+
+      // Set appropriate blocks of Y.
+      Y.block(cumulative_udim_row, 0, dynamics.UDim(ii), dynamics.XDim()) =
+        BiZi * lin.A;
+      Y.col(dynamics.XDim()).segment(cumulative_udim_row, dynamics.UDim(ii)) =
+        lin.Bs[ii].transpose() * zetas[ii];
 
       // Increment cumulative_udim_row.
       cumulative_udim_row += dynamics.UDim(ii);


### PR DESCRIPTION
I think this bit of code should be moved to the outer loop (iith player). It doesn't make a difference for the results but currently you assign it multiple times. The relevant tests still pass:
```
[----------] 2 tests from SolveLQGameTest
[ RUN      ] SolveLQGameTest.MatchesLyapunovIterations
[       OK ] SolveLQGameTest.MatchesLyapunovIterations (1 ms)
[ RUN      ] SolveLQGameTest.LocalNashEquilibrium
[       OK ] SolveLQGameTest.LocalNashEquilibrium (15 ms)
[----------] 2 tests from SolveLQGameTest (16 ms total)
```