### PR TITLE
Handle infeasible initial guess

### DIFF
--- a/exec/flat_roundabout_merging_example/main.cpp
+++ b/exec/flat_roundabout_merging_example/main.cpp
@@ -106,6 +106,7 @@ int main(int argc, char** argv) {
   ilqgames::SolverParams params;
   params.max_backtracking_steps = 100;
   params.linesearch = FLAGS_linesearch;
+  params.enforce_constraints_in_linesearch = true;
   params.trust_region_size = FLAGS_trust_region_size;
   params.initial_alpha_scaling = FLAGS_initial_alpha_scaling;
   params.convergence_tolerance = FLAGS_convergence_tolerance;

--- a/exec/receding_horizon_example/main.cpp
+++ b/exec/receding_horizon_example/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char** argv) {
       std::make_shared<ilqgames::ThreePlayerIntersectionExample>(params);
 
   // Solve the game in a receding horizon.
-  constexpr ilqgames::Time kFinalTime = 1.0;       // s
+  constexpr ilqgames::Time kFinalTime = 10.0;       // s
   constexpr ilqgames::Time kPlannerRuntime = 0.25;  // s
   const std::vector<std::shared_ptr<const ilqgames::SolverLog>> logs =
       RecedingHorizonSimulator(kFinalTime, kPlannerRuntime, problem.get());

--- a/exec/receding_horizon_example/main.cpp
+++ b/exec/receding_horizon_example/main.cpp
@@ -105,7 +105,7 @@ int main(int argc, char** argv) {
       std::make_shared<ilqgames::ThreePlayerIntersectionExample>(params);
 
   // Solve the game in a receding horizon.
-  constexpr ilqgames::Time kFinalTime = 10.0;       // s
+  constexpr ilqgames::Time kFinalTime = 1.0;       // s
   constexpr ilqgames::Time kPlannerRuntime = 0.25;  // s
   const std::vector<std::shared_ptr<const ilqgames::SolverLog>> logs =
       RecedingHorizonSimulator(kFinalTime, kPlannerRuntime, problem.get());

--- a/exec/roundabout_merging_example/main.cpp
+++ b/exec/roundabout_merging_example/main.cpp
@@ -106,6 +106,7 @@ int main(int argc, char** argv) {
   ilqgames::SolverParams params;
   params.max_backtracking_steps = 100;
   params.linesearch = FLAGS_linesearch;
+  params.enforce_constraints_in_linesearch = true;
   params.trust_region_size = FLAGS_trust_region_size;
   params.initial_alpha_scaling = FLAGS_initial_alpha_scaling;
   params.convergence_tolerance = FLAGS_convergence_tolerance;

--- a/exec/three_player_flat_intersection/main.cpp
+++ b/exec/three_player_flat_intersection/main.cpp
@@ -107,6 +107,7 @@ int main(int argc, char** argv) {
   ilqgames::SolverParams params;
   params.max_backtracking_steps = 100;
   params.linesearch = FLAGS_linesearch;
+  params.enforce_constraints_in_linesearch = true;
   params.trust_region_size = FLAGS_trust_region_size;
   params.initial_alpha_scaling = FLAGS_initial_alpha_scaling;
   params.convergence_tolerance = FLAGS_convergence_tolerance;

--- a/exec/three_player_flat_overtaking/main.cpp
+++ b/exec/three_player_flat_overtaking/main.cpp
@@ -108,6 +108,7 @@ int main(int argc, char** argv) {
   ilqgames::SolverParams params;
   params.max_backtracking_steps = 100;
   params.linesearch = FLAGS_linesearch;
+  params.enforce_constraints_in_linesearch = true;
   params.trust_region_size = FLAGS_trust_region_size;
   params.initial_alpha_scaling = FLAGS_initial_alpha_scaling;
   params.convergence_tolerance = FLAGS_convergence_tolerance;

--- a/exec/three_player_intersection/main.cpp
+++ b/exec/three_player_intersection/main.cpp
@@ -109,6 +109,7 @@ int main(int argc, char** argv) {
   params.max_backtracking_steps = 100;
   //  params.max_solver_iters = 10000;
   params.linesearch = FLAGS_linesearch;
+  params.enforce_constraints_in_linesearch = true;
   params.trust_region_size = FLAGS_trust_region_size;
   params.initial_alpha_scaling = FLAGS_initial_alpha_scaling;
   params.convergence_tolerance = FLAGS_convergence_tolerance;

--- a/exec/three_player_overtaking/main.cpp
+++ b/exec/three_player_overtaking/main.cpp
@@ -61,7 +61,8 @@
 // Optional log saving and visualization.
 DEFINE_bool(save, false, "Optionally save solver logs to disk.");
 DEFINE_bool(viz, true, "Visualize results in a GUI.");
-DEFINE_bool(last_traj, false, "Should the solver only dump the last trajectory?");
+DEFINE_bool(last_traj, false,
+            "Should the solver only dump the last trajectory?");
 DEFINE_string(experiment_name, "", "Name for the experiment.");
 
 // Linesearch parameters.
@@ -103,6 +104,7 @@ int main(int argc, char** argv) {
   // Set up the game.
   ilqgames::SolverParams params;
   params.max_backtracking_steps = 100;
+  params.enforce_constraints_in_linesearch = true;
   params.linesearch = FLAGS_linesearch;
   params.trust_region_size = FLAGS_trust_region_size;
   params.initial_alpha_scaling = FLAGS_initial_alpha_scaling;
@@ -130,12 +132,11 @@ int main(int argc, char** argv) {
     LOG(INFO) << "Solution may not be a local Nash.";
 
   // Dump the logs and/or exit.
-  if (FLAGS_save) { 
-    if (FLAGS_experiment_name == "") { 
-          CHECK(log->Save(FLAGS_last_traj)); 
-    }
-    else { 
-      CHECK(log->Save(FLAGS_last_traj,FLAGS_experiment_name)); 
+  if (FLAGS_save) {
+    if (FLAGS_experiment_name == "") {
+      CHECK(log->Save(FLAGS_last_traj));
+    } else {
+      CHECK(log->Save(FLAGS_last_traj, FLAGS_experiment_name));
     }
   }
   if (!FLAGS_viz) return 0;

--- a/exec/two_player_collision/main.cpp
+++ b/exec/two_player_collision/main.cpp
@@ -61,7 +61,8 @@
 // Optional log saving and visualization.
 DEFINE_bool(save, false, "Optionally save solver logs to disk.");
 DEFINE_bool(viz, true, "Visualize results in a GUI.");
-DEFINE_bool(last_traj, false, "Should the solver only dump the last trajectory?");
+DEFINE_bool(last_traj, false,
+            "Should the solver only dump the last trajectory?");
 DEFINE_string(experiment_name, "", "Name for the experiment.");
 
 // Linesearch parameters.
@@ -104,11 +105,11 @@ int main(int argc, char** argv) {
   ilqgames::SolverParams params;
   params.max_backtracking_steps = 100;
   params.linesearch = FLAGS_linesearch;
+  params.enforce_constraints_in_linesearch = true;
   params.trust_region_size = FLAGS_trust_region_size;
   params.initial_alpha_scaling = FLAGS_initial_alpha_scaling;
   params.convergence_tolerance = FLAGS_convergence_tolerance;
-  auto problem =
-      std::make_shared<ilqgames::TwoPlayerCollisionExample>(params);
+  auto problem = std::make_shared<ilqgames::TwoPlayerCollisionExample>(params);
 
   // Solve the game.
   const auto start = std::chrono::system_clock::now();
@@ -130,12 +131,11 @@ int main(int argc, char** argv) {
     LOG(INFO) << "Solution may not be a local Nash.";
 
   // Dump the logs and/or exit.
-  if (FLAGS_save) { 
-    if (FLAGS_experiment_name == "") { 
-          CHECK(log->Save(FLAGS_last_traj)); 
-    }
-    else { 
-      CHECK(log->Save(FLAGS_last_traj,FLAGS_experiment_name)); 
+  if (FLAGS_save) {
+    if (FLAGS_experiment_name == "") {
+      CHECK(log->Save(FLAGS_last_traj));
+    } else {
+      CHECK(log->Save(FLAGS_last_traj, FLAGS_experiment_name));
     }
   }
   if (!FLAGS_viz) return 0;

--- a/include/ilqgames/constraint/constraint.h
+++ b/include/ilqgames/constraint/constraint.h
@@ -99,8 +99,8 @@ class Constraint : public Cost {
   // when an initial iterate is infeasible.
   std::unique_ptr<const Cost> equivalent_cost_;
   static constexpr float kBarrierWeight = 0.1;
-  static constexpr float kEquivalentCostWeight = 10.0;
-  static constexpr float kCostBuffer = 3.0;
+  static constexpr float kEquivalentCostWeight = 10000.0;
+  static constexpr float kCostBuffer = 1.0;
 };  //\class Constraint
 
 }  // namespace ilqgames

--- a/include/ilqgames/constraint/constraint.h
+++ b/include/ilqgames/constraint/constraint.h
@@ -92,13 +92,15 @@ class Constraint : public Cost {
   }
 
  protected:
-  explicit Constraint(const std::string& name = "") : Cost(1.0, name) {}
+  explicit Constraint(const std::string& name = "")
+      : Cost(kBarrierWeight, name) {}
 
   // "Equivalent" well-defined cost to encourage constraint satisfaction, e.g.,
   // when an initial iterate is infeasible.
   std::unique_ptr<const Cost> equivalent_cost_;
-  static constexpr float kEquivalentCostWeight = 100.0;
-  static constexpr float kCostBuffer = 1.0;
+  static constexpr float kBarrierWeight = 0.1;
+  static constexpr float kEquivalentCostWeight = 10.0;
+  static constexpr float kCostBuffer = 3.0;
 };  //\class Constraint
 
 }  // namespace ilqgames

--- a/include/ilqgames/constraint/constraint.h
+++ b/include/ilqgames/constraint/constraint.h
@@ -65,8 +65,15 @@ class Constraint : public Cost {
   // Set or multiplicatively scale the barrier weight. This will typically
   // decrease with successive solves in order to improve the approximation of
   // the barrier-free objective.
-  void SetBarrierWeight(float weight) { weight_ = weight; }
-  void ScaleBarrierWeight(float scale) { weight_ *= scale; }
+  void ResetBarrierWeight() {
+    weight_ = kInitialBarrierWeight;
+    if (equivalent_cost_.get())
+      equivalent_cost_->SetWeight(kInitialEquivalentCostWeight);
+  }
+  void ScaleBarrierWeight(float scale) {
+    weight_ *= scale;
+    if (equivalent_cost_.get()) equivalent_cost_->ScaleWeight(scale);
+  }
 
   // Check if this constraint is satisfied, and optionally return the value of a
   // function whose zero sub-level set corresponds to the feasible set.
@@ -97,9 +104,9 @@ class Constraint : public Cost {
 
   // "Equivalent" well-defined cost to encourage constraint satisfaction, e.g.,
   // when an initial iterate is infeasible.
-  std::unique_ptr<const Cost> equivalent_cost_;
-  static constexpr float kInitialBarrierWeight = 1.0;
-  static constexpr float kInitialEquivalentCostWeight = 1.0;
+  std::unique_ptr<Cost> equivalent_cost_;
+  static constexpr float kInitialBarrierWeight = 100.0;
+  static constexpr float kInitialEquivalentCostWeight = 10.0;
   static constexpr float kCostBuffer = 1.0;
 };  //\class Constraint
 

--- a/include/ilqgames/constraint/constraint.h
+++ b/include/ilqgames/constraint/constraint.h
@@ -93,13 +93,13 @@ class Constraint : public Cost {
 
  protected:
   explicit Constraint(const std::string& name = "")
-      : Cost(kBarrierWeight, name) {}
+      : Cost(kInitialBarrierWeight, name) {}
 
   // "Equivalent" well-defined cost to encourage constraint satisfaction, e.g.,
   // when an initial iterate is infeasible.
   std::unique_ptr<const Cost> equivalent_cost_;
-  static constexpr float kBarrierWeight = 0.1;
-  static constexpr float kEquivalentCostWeight = 10000.0;
+  static constexpr float kInitialBarrierWeight = 1.0;
+  static constexpr float kInitialEquivalentCostWeight = 1.0;
   static constexpr float kCostBuffer = 1.0;
 };  //\class Constraint
 

--- a/include/ilqgames/constraint/constraint.h
+++ b/include/ilqgames/constraint/constraint.h
@@ -70,8 +70,12 @@ class Constraint : public Cost {
 
   // Check if this constraint is satisfied, and optionally return the value of a
   // function whose zero sub-level set corresponds to the feasible set.
-  virtual bool IsSatisfied(Time t, const VectorXf& input,
-                           float* level = nullptr) const = 0;
+  virtual bool IsSatisfiedLevel(Time t, const VectorXf& input,
+                                float* level) const = 0;
+  bool IsSatisfied(Time t, const VectorXf& input) const {
+    float level;
+    return IsSatisfiedLevel(t, input, &level);
+  }
 
   // Evaluate the barrier at the current time and input.
   float Evaluate(Time t, const VectorXf& input) const;
@@ -82,7 +86,6 @@ class Constraint : public Cost {
                             VectorXf* grad) const = 0;
 
   // Accessors.
-  const std::string& Name() const { return name_; }
   const Cost& EquivalentCost() const {
     CHECK_NOTNULL(equivalent_cost_.get());
     return *equivalent_cost_;

--- a/include/ilqgames/constraint/polyline2_signed_distance_constraint.h
+++ b/include/ilqgames/constraint/polyline2_signed_distance_constraint.h
@@ -77,7 +77,7 @@ class Polyline2SignedDistanceConstraint : public TimeInvariantConstraint {
 
   // Check if this constraint is satisfied, and optionally return the value of a
   // function whose zero sub-level set corresponds to the feasible set.
-  bool IsSatisfied(const VectorXf& input, float* level = nullptr) const;
+  bool IsSatisfiedLevel(const VectorXf& input, float* level) const;
 
   // Quadraticize this cost at the given time and input, and add to the running
   // sum of gradients and Hessians.

--- a/include/ilqgames/constraint/polyline2_signed_distance_constraint.h
+++ b/include/ilqgames/constraint/polyline2_signed_distance_constraint.h
@@ -46,6 +46,7 @@
 #define ILQGAMES_CONSTRAINT_POLYLINE2_SIGNED_DISTANCE_CONSTRAINT_H
 
 #include <ilqgames/constraint/time_invariant_constraint.h>
+#include <ilqgames/cost/semiquadratic_polyline2_cost.h>
 #include <ilqgames/geometry/polyline2.h>
 #include <ilqgames/utils/types.h>
 
@@ -65,7 +66,14 @@ class Polyline2SignedDistanceConstraint : public TimeInvariantConstraint {
         signed_threshold_sq_(sgn(threshold) * threshold * threshold),
         oriented_right_(oriented_right),
         xidx_(position_idxs.first),
-        yidx_(position_idxs.second) {}
+        yidx_(position_idxs.second) {
+    // Set equivalent cost pointer.
+    const float new_threshold =
+      (oriented_right) ? threshold + kCostBuffer : threshold - kCostBuffer;
+    equivalent_cost_.reset(new SemiquadraticPolyline2Cost(
+        kEquivalentCostWeight, polyline, position_idxs, new_threshold,
+        !oriented_right, name + "/Cost"));
+  }
 
   // Check if this constraint is satisfied, and optionally return the value of a
   // function whose zero sub-level set corresponds to the feasible set.

--- a/include/ilqgames/constraint/polyline2_signed_distance_constraint.h
+++ b/include/ilqgames/constraint/polyline2_signed_distance_constraint.h
@@ -71,7 +71,7 @@ class Polyline2SignedDistanceConstraint : public TimeInvariantConstraint {
     const float new_threshold =
       (oriented_right) ? threshold + kCostBuffer : threshold - kCostBuffer;
     equivalent_cost_.reset(new SemiquadraticPolyline2Cost(
-        kEquivalentCostWeight, polyline, position_idxs, new_threshold,
+        kInitialEquivalentCostWeight, polyline, position_idxs, new_threshold,
         !oriented_right, name + "/Cost"));
   }
 

--- a/include/ilqgames/constraint/proximity_constraint.h
+++ b/include/ilqgames/constraint/proximity_constraint.h
@@ -73,7 +73,7 @@ class ProximityConstraint : public TimeInvariantConstraint {
     CHECK(!inside) << "Right now we only have a cost that supports outside "
                       "oriented constraints.";
     const float new_threshold = threshold - kCostBuffer;
-    equivalent_cost_.reset(new ProximityCost(kEquivalentCostWeight,
+    equivalent_cost_.reset(new ProximityCost(kInitialEquivalentCostWeight,
                                              position_idxs1, position_idxs2,
                                              new_threshold, name + "/Cost"));
   }

--- a/include/ilqgames/constraint/proximity_constraint.h
+++ b/include/ilqgames/constraint/proximity_constraint.h
@@ -52,6 +52,7 @@
 
 #include <string>
 #include <utility>
+#include <math.h>
 
 namespace ilqgames {
 
@@ -69,8 +70,7 @@ class ProximityConstraint : public TimeInvariantConstraint {
         xidx2_(position_idxs2.first),
         yidx2_(position_idxs2.second) {
     // Set equivalent cost pointer.
-    const float new_threshold = threshold - kCostBuffer;
-    CHECK_GT(new_threshold, 0.0);
+    const float new_threshold = std::max<float>(threshold - kCostBuffer, 0.0);
     equivalent_cost_.reset(new ProximityCost(kEquivalentCostWeight,
                                              position_idxs1, position_idxs2,
                                              new_threshold, name + "/Cost"));

--- a/include/ilqgames/constraint/proximity_constraint.h
+++ b/include/ilqgames/constraint/proximity_constraint.h
@@ -72,7 +72,7 @@ class ProximityConstraint : public TimeInvariantConstraint {
     // Set equivalent cost pointer.
     CHECK(!inside) << "Right now we only have a cost that supports outside "
                       "oriented constraints.";
-    const float new_threshold = threshold - kCostBuffer;
+    const float new_threshold = threshold + kCostBuffer;
     equivalent_cost_.reset(new ProximityCost(kInitialEquivalentCostWeight,
                                              position_idxs1, position_idxs2,
                                              new_threshold, name + "/Cost"));

--- a/include/ilqgames/constraint/proximity_constraint.h
+++ b/include/ilqgames/constraint/proximity_constraint.h
@@ -78,7 +78,7 @@ class ProximityConstraint : public TimeInvariantConstraint {
 
   // Check if this constraint is satisfied, and optionally return the value of a
   // function whose zero sub-level set corresponds to the feasible set.
-  bool IsSatisfied(const VectorXf& input, float* level = nullptr) const;
+  bool IsSatisfiedLevel(const VectorXf& input, float* level) const;
 
   // Quadraticize this cost at the given time and input, and add to the running
   // sum of gradients and Hessians.

--- a/include/ilqgames/constraint/proximity_constraint.h
+++ b/include/ilqgames/constraint/proximity_constraint.h
@@ -47,6 +47,7 @@
 #define ILQGAMES_CONSTRAINT_PROXIMITY_CONSTRAINT_H
 
 #include <ilqgames/constraint/time_invariant_constraint.h>
+#include <ilqgames/cost/proximity_cost.h>
 #include <ilqgames/utils/types.h>
 
 #include <string>
@@ -66,7 +67,14 @@ class ProximityConstraint : public TimeInvariantConstraint {
         xidx1_(position_idxs1.first),
         yidx1_(position_idxs1.second),
         xidx2_(position_idxs2.first),
-        yidx2_(position_idxs2.second) {}
+        yidx2_(position_idxs2.second) {
+    // Set equivalent cost pointer.
+    const float new_threshold = threshold - kCostBuffer;
+    CHECK_GT(new_threshold, 0.0);
+    equivalent_cost_.reset(new ProximityCost(kEquivalentCostWeight,
+                                             position_idxs1, position_idxs2,
+                                             new_threshold, name + "/Cost"));
+  }
 
   // Check if this constraint is satisfied, and optionally return the value of a
   // function whose zero sub-level set corresponds to the feasible set.

--- a/include/ilqgames/constraint/proximity_constraint.h
+++ b/include/ilqgames/constraint/proximity_constraint.h
@@ -50,9 +50,9 @@
 #include <ilqgames/cost/proximity_cost.h>
 #include <ilqgames/utils/types.h>
 
+#include <math.h>
 #include <string>
 #include <utility>
-#include <math.h>
 
 namespace ilqgames {
 
@@ -70,7 +70,9 @@ class ProximityConstraint : public TimeInvariantConstraint {
         xidx2_(position_idxs2.first),
         yidx2_(position_idxs2.second) {
     // Set equivalent cost pointer.
-    const float new_threshold = std::max<float>(threshold - kCostBuffer, 0.0);
+    CHECK(!inside) << "Right now we only have a cost that supports outside "
+                      "oriented constraints.";
+    const float new_threshold = threshold - kCostBuffer;
     equivalent_cost_.reset(new ProximityCost(kEquivalentCostWeight,
                                              position_idxs1, position_idxs2,
                                              new_threshold, name + "/Cost"));

--- a/include/ilqgames/constraint/single_dimension_constraint.h
+++ b/include/ilqgames/constraint/single_dimension_constraint.h
@@ -73,7 +73,7 @@ class SingleDimensionConstraint : public TimeInvariantConstraint {
 
   // Check if this constraint is satisfied, and optionally return the value of a
   // function whose zero sub-level set corresponds to the feasible set.
-  bool IsSatisfied(const VectorXf& input, float* level = nullptr) const;
+  bool IsSatisfiedLevel(const VectorXf& input, float* level) const;
 
   // Quadraticize this cost at the given time and input, and add to the running
   // sum of gradients and Hessians.

--- a/include/ilqgames/constraint/single_dimension_constraint.h
+++ b/include/ilqgames/constraint/single_dimension_constraint.h
@@ -46,6 +46,7 @@
 #define ILQGAMES_CONSTRAINT_SINGLE_DIMENSION_CONSTRAINT_H
 
 #include <ilqgames/constraint/time_invariant_constraint.h>
+#include <ilqgames/cost/semiquadratic_cost.h>
 #include <ilqgames/utils/types.h>
 
 #include <string>
@@ -60,7 +61,15 @@ class SingleDimensionConstraint : public TimeInvariantConstraint {
       : TimeInvariantConstraint(name),
         dimension_(dimension),
         threshold_(threshold),
-        oriented_right_(oriented_right) {}
+        oriented_right_(oriented_right) {
+    // Set equivalent cost pointer.
+    const float new_threshold =
+        (oriented_right) ? threshold + kCostBuffer : threshold - kCostBuffer;
+    CHECK_GE(dimension, 0);
+    equivalent_cost_.reset(
+        new SemiquadraticCost(kEquivalentCostWeight, dimension, new_threshold,
+                              !oriented_right, name + "/Cost"));
+  }
 
   // Check if this constraint is satisfied, and optionally return the value of a
   // function whose zero sub-level set corresponds to the feasible set.

--- a/include/ilqgames/constraint/single_dimension_constraint.h
+++ b/include/ilqgames/constraint/single_dimension_constraint.h
@@ -67,8 +67,8 @@ class SingleDimensionConstraint : public TimeInvariantConstraint {
         (oriented_right) ? threshold + kCostBuffer : threshold - kCostBuffer;
     CHECK_GE(dimension, 0);
     equivalent_cost_.reset(
-        new SemiquadraticCost(kEquivalentCostWeight, dimension, new_threshold,
-                              !oriented_right, name + "/Cost"));
+        new SemiquadraticCost(kInitialEquivalentCostWeight, dimension,
+                              new_threshold, !oriented_right, name + "/Cost"));
   }
 
   // Check if this constraint is satisfied, and optionally return the value of a

--- a/include/ilqgames/constraint/time_invariant_constraint.h
+++ b/include/ilqgames/constraint/time_invariant_constraint.h
@@ -57,12 +57,11 @@ class TimeInvariantConstraint : public Constraint {
 
   // Check if this constraint is satisfied, and optionally return the value of a
   // function whose zero sub-level set corresponds to the feasible set.
-  bool IsSatisfied(Time t, const VectorXf& input,
-                   float* level = nullptr) const {
-    return IsSatisfied(input, level);
+  bool IsSatisfiedLevel(Time t, const VectorXf& input, float* level) const {
+    CHECK_NOTNULL(level);
+    return IsSatisfiedLevel(input, level);
   };
-  virtual bool IsSatisfied(const VectorXf& input,
-                           float* level = nullptr) const = 0;
+  virtual bool IsSatisfiedLevel(const VectorXf& input, float* level) const = 0;
 
   // Evaluate the barrier at the current input (use base class implementation
   // and provide arbitrary time).

--- a/include/ilqgames/cost/cost.h
+++ b/include/ilqgames/cost/cost.h
@@ -68,6 +68,10 @@ class Cost {
   // Reset the initial time associated to this cost.
   static void ResetInitialTime(Time t0) { initial_time_ = t0; };
 
+  // Reset and scale weight.
+  void SetWeight(float weight) { weight_ = weight; }
+  void ScaleWeight(float scale) { weight_ *= scale; }
+
  protected:
   explicit Cost(float weight, const std::string& name = "")
       : weight_(weight), name_(name) {}

--- a/include/ilqgames/cost/player_cost.h
+++ b/include/ilqgames/cost/player_cost.h
@@ -92,8 +92,11 @@ class PlayerCost {
   void TurnConstraintsOn() { are_constraints_on_ = true; }
   void TurnConstraintsOff() { are_constraints_on_ = false; }
 
-  // Check whether constraints are satisfied at the given time and state.
-  bool CheckConstraints(Time t, const VectorXf& x) const;
+  // Check whether constraints are satisfied at the given time.
+  bool CheckConstraints(Time t, const VectorXf& x,
+                        const std::vector<VectorXf>& us) const;
+  size_t NumStateConstraints() const { return state_constraints_.size(); }
+  size_t NumControlConstraints() const { return control_constraints_.size(); }
 
   // Scale all weights associated with all constraint barriers by the given
   // multiplier, which ought to be less than 1.0. Can also reset all weights

--- a/include/ilqgames/cost/player_cost.h
+++ b/include/ilqgames/cost/player_cost.h
@@ -57,9 +57,11 @@ namespace ilqgames {
 class PlayerCost {
  public:
   ~PlayerCost() {}
-  explicit PlayerCost(float state_regularization = 0.0,
+  explicit PlayerCost(const std::string& name = "",
+                      float state_regularization = 0.0,
                       float control_regularization = 0.0)
-      : state_regularization_(state_regularization),
+      : name_(name),
+        state_regularization_(state_regularization),
         control_regularization_(control_regularization),
         are_constraints_on_(true) {}
 
@@ -91,6 +93,7 @@ class PlayerCost {
   // with their"equivalent" costs).
   void TurnConstraintsOn() { are_constraints_on_ = true; }
   void TurnConstraintsOff() { are_constraints_on_ = false; }
+  bool AreConstraintsOn() const { return are_constraints_on_; }
 
   // Check whether constraints are satisfied at the given time.
   bool CheckConstraints(Time t, const VectorXf& x,
@@ -117,6 +120,9 @@ class PlayerCost {
   }
 
  private:
+  // Name to be used with error msgs.
+  const std::string name_;
+
   // State costs and control costs.
   std::vector<std::shared_ptr<Cost>> state_costs_;
   CostMap<Cost> control_costs_;

--- a/include/ilqgames/cost/player_cost.h
+++ b/include/ilqgames/cost/player_cost.h
@@ -60,7 +60,8 @@ class PlayerCost {
   explicit PlayerCost(float state_regularization = 0.0,
                       float control_regularization = 0.0)
       : state_regularization_(state_regularization),
-        control_regularization_(control_regularization) {}
+        control_regularization_(control_regularization),
+        are_constraints_on_(true) {}
 
   // Add new state and control costs for this player.
   void AddStateCost(const std::shared_ptr<Cost>& cost);
@@ -85,6 +86,11 @@ class PlayerCost {
   // *Does* account for cost barriers due to inequality constraints.
   QuadraticCostApproximation Quadraticize(
       Time t, const VectorXf& x, const std::vector<VectorXf>& us) const;
+
+  // Turn all constraints either "on" or "off" (in which case they are replaced
+  // with their"equivalent" costs).
+  void TurnConstraintsOn() { are_constraints_on_ = true; }
+  void TurnConstraintsOff() { are_constraints_on_ = false; }
 
   // Check whether constraints are satisfied at the given time and state.
   bool CheckConstraints(Time t, const VectorXf& x) const;
@@ -117,6 +123,7 @@ class PlayerCost {
   // this player's input.
   std::vector<std::shared_ptr<Constraint>> state_constraints_;
   CostMap<Constraint> control_constraints_;
+  bool are_constraints_on_;
 
   // Regularization on costs.
   const float state_regularization_, control_regularization_;

--- a/include/ilqgames/solver/game_solver.h
+++ b/include/ilqgames/solver/game_solver.h
@@ -162,7 +162,12 @@ class GameSolver {
                              OperatingPoint* current_operating_point,
                              bool* has_converged,
                              std::vector<float>* total_costs,
-                             bool check_trust_region = true) const;
+                             bool check_trust_region = true,
+                             bool* satisfies_constraints = nullptr) const;
+
+  // Check if a given operating point's state trajectory satisfies all
+  // constraints.
+  bool CheckConstraints(const OperatingPoint& op) const;
 
   // Dynamical system.
   const std::shared_ptr<const MultiPlayerIntegrableSystem> dynamics_;

--- a/include/ilqgames/solver/game_solver.h
+++ b/include/ilqgames/solver/game_solver.h
@@ -142,8 +142,8 @@ class GameSolver {
   // costs for all players at the new operating point.
   virtual bool ModifyLQStrategies(std::vector<Strategy>* strategies,
                                   OperatingPoint* current_operating_point,
+                                  bool* is_new_operating_point_feasible,
                                   bool* has_converged,
-                                  bool* was_initial_point_feasible,
                                   std::vector<float>* total_costs) const;
 
   // Compute distance (infinity norm) between states in the given dimensions.
@@ -164,10 +164,6 @@ class GameSolver {
                              std::vector<float>* total_costs,
                              bool check_trust_region = true,
                              bool* satisfies_constraints = nullptr) const;
-
-  // Check if a given operating point's state trajectory satisfies all
-  // constraints.
-  bool CheckConstraints(const OperatingPoint& op) const;
 
   // Dynamical system.
   const std::shared_ptr<const MultiPlayerIntegrableSystem> dynamics_;

--- a/include/ilqgames/solver/solver_params.h
+++ b/include/ilqgames/solver/solver_params.h
@@ -60,6 +60,7 @@ struct SolverParams {
   float initial_alpha_scaling = 0.5;
   float geometric_alpha_scaling = 0.5;
   size_t max_backtracking_steps = 10;
+  bool enforce_constraints_in_linesearch = false;
 
   // Maximum absolute difference between states in the given dimension to
   // satisfy trust region. Only active if linesearching is on. If dimensions

--- a/src/compute_strategy_costs.cpp
+++ b/src/compute_strategy_costs.cpp
@@ -62,7 +62,7 @@ std::vector<float> ComputeStrategyCosts(
     const std::vector<Strategy>& strategies,
     const OperatingPoint& operating_point,
     const MultiPlayerIntegrableSystem& dynamics, const VectorXf& x0,
-    float time_step, bool open_loop = false) {
+    float time_step, bool open_loop) {
   // Start at the initial state.
   VectorXf x(x0);
   Time t = 0.0;

--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -52,7 +52,7 @@ namespace ilqgames {
 
 float Constraint::Evaluate(Time t, const VectorXf& input) const {
   float level = 0.0;
-  CHECK(IsSatisfied(t, input, &level));
+  CHECK(IsSatisfiedLevel(t, input, &level));
   CHECK_LT(level, 0.0);
 
   // For a concise introduction to log barrier methods, please refer to

--- a/src/flat_roundabout_merging_example.cpp
+++ b/src/flat_roundabout_merging_example.cpp
@@ -242,7 +242,7 @@ FlatRoundaboutMergingExample::FlatRoundaboutMergingExample(
   x0_ = dynamics_->ToLinearSystemState(x0);
 
   // Set up costs for all players.
-  PlayerCost p1_cost, p2_cost, p3_cost, p4_cost;
+  PlayerCost p1_cost("P1"), p2_cost("P2"), p3_cost("P3"), p4_cost("P4");
 
   // Stay in lanes.
   const std::shared_ptr<QuadraticPolyline2Cost> p1_lane_cost(

--- a/src/game_solver.cpp
+++ b/src/game_solver.cpp
@@ -143,7 +143,6 @@ bool GameSolver::Solve(const VectorXf& x0,
   // which occurs after solving the LQ game.
   bool was_operating_point_feasible;
   std::vector<float> total_costs;
-
   last_operating_point.swap(current_operating_point);
   CurrentOperatingPoint(last_operating_point, current_strategies,
                         &current_operating_point, &has_converged, &total_costs,

--- a/src/game_solver.cpp
+++ b/src/game_solver.cpp
@@ -126,8 +126,7 @@ bool GameSolver::Solve(const VectorXf& x0,
   size_t num_iterations_since_barrier_rescaling = 0;
   bool has_converged = false;
 
-  // If the initial operating point is infeasible then use cost version of
-  // constraints.
+  // Turn constraints on.
   auto turn_constraints_on = [this]() {
     for (auto& cost : player_costs_) cost.TurnConstraintsOn();
   };  // turn_constraints_on
@@ -136,12 +135,8 @@ bool GameSolver::Solve(const VectorXf& x0,
     for (auto& cost : player_costs_) cost.TurnConstraintsOff();
   };  // turn_constraints_on
 
-  bool was_operating_point_feasible = CheckConstraints(initial_operating_point);
-  if (!was_operating_point_feasible)
-    turn_constraints_off();
-  else
-    turn_constraints_on();
-
+  turn_constraints_on();
+  bool was_operating_point_feasible = true;
   std::vector<float> total_costs =
       ComputeStrategyCosts(player_costs_, current_strategies,
                            current_operating_point, *dynamics_, x0, time_step_);
@@ -189,6 +184,9 @@ bool GameSolver::Solve(const VectorXf& x0,
       turn_constraints_on();
     else
       turn_constraints_off();
+
+    std::cout << "operating point feasible: " << was_operating_point_feasible
+              << std::endl;
 
     // Linearize dynamics and quadraticize costs for all players about the new
     // operating point, only if the system can't be treated as linear from the

--- a/src/game_solver.cpp
+++ b/src/game_solver.cpp
@@ -111,8 +111,11 @@ bool GameSolver::Solve(const VectorXf& x0,
 
   // Last and current operating points. Make sure the last one starts from the
   // current state so that the current one will start there as well.
+  // NOTE: setting the current operating point to start at x0 is critical to the
+  // constraint satisfaction check at the first iteration.
   OperatingPoint last_operating_point(initial_operating_point);
   OperatingPoint current_operating_point(initial_operating_point);
+  current_operating_point.xs[0] = x0;
   last_operating_point.xs[0] = x0;
 
   // Current strategies.
@@ -184,9 +187,6 @@ bool GameSolver::Solve(const VectorXf& x0,
       turn_constraints_on();
     else
       turn_constraints_off();
-
-    std::cout << "operating point feasible: " << was_operating_point_feasible
-              << std::endl;
 
     // Linearize dynamics and quadraticize costs for all players about the new
     // operating point, only if the system can't be treated as linear from the
@@ -325,8 +325,8 @@ bool GameSolver::CurrentOperatingPoint(
         // really ever lead to a fault though since the solver should be
         // backtracking if this returns false anyway.
         if (checked_constraints)
-          LOG(WARNING) << "Failed trust region on time step " << kk
-                       << " but satisfied constraints up till then.";
+          VLOG(2) << "Failed trust region on time step " << kk
+                  << " but satisfied constraints up till then.";
         return false;
       }
     }

--- a/src/game_solver.cpp
+++ b/src/game_solver.cpp
@@ -308,9 +308,11 @@ bool GameSolver::CurrentOperatingPoint(
 
     const float delta_x_distance = StateDistance(
         x, last_operating_point.xs[kk], params_.trust_region_dimensions);
+    std::cout << "satisfies constraints pointer is not null: "
+              << static_cast<bool>(satisfies_constraints) << std::endl;
     const bool checked_constraints =
-        (satisfies_constraints) ? check_all_constraints(t, x, current_us)
-                                : true;
+        check_all_constraints(t, x, current_us) || !satisfies_constraints;
+
     *has_converged &= (delta_x_distance < params_.convergence_tolerance &&
                        checked_constraints);
 

--- a/src/game_solver.cpp
+++ b/src/game_solver.cpp
@@ -253,7 +253,7 @@ bool GameSolver::Solve(const VectorXf& x0,
         params_.convergence_tolerance);
   }
 
-  CHECK(was_operating_point_feasible) << "has_converged is: " << has_converged;
+  CHECK(!has_converged || (has_converged && was_operating_point_feasible));
 
   // Set final strategies and operating point.
   final_strategies->swap(current_strategies);

--- a/src/player_cost.cpp
+++ b/src/player_cost.cpp
@@ -61,7 +61,7 @@ template <typename T>
 void AccumulateControlCosts(const CostMap<T>& costs, Time t,
                             const std::vector<VectorXf>& us,
                             float regularization, QuadraticCostApproximation* q,
-                            bool is_constraint_on = true) {
+                            bool are_constraints_on = true) {
   for (const auto& pair : costs) {
     const PlayerIndex player = pair.first;
     const auto& cost = pair.second;
@@ -80,7 +80,7 @@ void AccumulateControlCosts(const CostMap<T>& costs, Time t,
       iter = inserted_pair.first;
     }
 
-    if (is_constraint_on) {
+    if (are_constraints_on) {
       cost->Quadraticize(t, us[player], &(iter->second.hess),
                          &(iter->second.grad));
     } else {
@@ -186,9 +186,14 @@ QuadraticCostApproximation PlayerCost::Quadraticize(
   return q;
 }
 
-bool PlayerCost::CheckConstraints(Time t, const VectorXf& x) const {
+bool PlayerCost::CheckConstraints(Time t, const VectorXf& x,
+                                  const std::vector<VectorXf>& us) const {
   for (const auto& constraint : state_constraints_) {
     if (!constraint->IsSatisfied(t, x)) return false;
+  }
+
+  for (const auto& pair : control_constraints_) {
+    if (!pair.second->IsSatisfied(t, us[pair.first])) return false;
   }
 
   return true;

--- a/src/player_cost.cpp
+++ b/src/player_cost.cpp
@@ -189,12 +189,20 @@ QuadraticCostApproximation PlayerCost::Quadraticize(
 bool PlayerCost::CheckConstraints(Time t, const VectorXf& x,
                                   const std::vector<VectorXf>& us) const {
   for (const auto& constraint : state_constraints_) {
-    if (!constraint->IsSatisfied(t, x)) return false;
+    if (!constraint->IsSatisfied(t, x)) {
+      VLOG(2) << name_ << ": failed to satisfy constraint "
+              << constraint->Name();
+      return false;
+    }
   }
 
-  for (const auto& pair : control_constraints_) {
-    if (!pair.second->IsSatisfied(t, us[pair.first])) return false;
-  }
+  // for (const auto& pair : control_constraints_) {
+  //   if (!pair.second->IsSatisfied(t, us[pair.first])) {
+  //     VLOG(2) << name_ + ": Failed to satisfy constraint "
+  //             << pair.second->Name();
+  //     return false;
+  //   }
+  // }
 
   return true;
 }

--- a/src/polyline2_signed_distance_constraint.cpp
+++ b/src/polyline2_signed_distance_constraint.cpp
@@ -51,8 +51,8 @@
 
 namespace ilqgames {
 
-bool Polyline2SignedDistanceConstraint::IsSatisfied(const VectorXf& input,
-                                                    float* level) const {
+bool Polyline2SignedDistanceConstraint::IsSatisfiedLevel(const VectorXf& input,
+                                                         float* level) const {
   CHECK_LT(xidx_, input.size());
   CHECK_LT(yidx_, input.size());
 
@@ -63,7 +63,7 @@ bool Polyline2SignedDistanceConstraint::IsSatisfied(const VectorXf& input,
 
   // Maybe set level.
   const float sign = (oriented_right_) ? 1.0 : -1.0;
-  if (level) *level = sign * (signed_threshold_sq_ - signed_distance_sq);
+  *level = sign * (signed_threshold_sq_ - signed_distance_sq);
 
   return (oriented_right_) ? signed_distance_sq > signed_threshold_sq_
                            : signed_distance_sq < signed_threshold_sq_;

--- a/src/problem.cpp
+++ b/src/problem.cpp
@@ -68,8 +68,8 @@ std::shared_ptr<SolverLog> Problem::Solve(Time max_runtime) {
   if (!solver_->Solve(x0_, *operating_point_, *strategies_,
                       &final_operating_point, &final_strategies, log.get(),
                       max_runtime)) {
-    LOG(WARNING) << "Solver failed. Not updating operating point and "
-                    "strategies to failed solution.";
+    VLOG(0) << "Solver failed. Not updating operating point and "
+               "strategies to failed solution.";
     return log;
   }
 

--- a/src/proximity_constraint.cpp
+++ b/src/proximity_constraint.cpp
@@ -52,8 +52,8 @@
 
 namespace ilqgames {
 
-bool ProximityConstraint::IsSatisfied(const VectorXf& input,
-                                      float* level) const {
+bool ProximityConstraint::IsSatisfiedLevel(const VectorXf& input,
+                                           float* level) const {
   const float dx = input(xidx1_) - input(xidx2_);
   const float dy = input(yidx1_) - input(yidx2_);
   const float delta_sq = dx * dx + dy * dy;
@@ -62,7 +62,7 @@ bool ProximityConstraint::IsSatisfied(const VectorXf& input,
   const float sign = (inside_) ? -1.0 : 1.0;
 
   // Maybe populate level.
-  if (level) *level = sign * (threshold_sq_ - delta_sq);
+  *level = sign * (threshold_sq_ - delta_sq);
 
   return (inside_) ? delta_sq < threshold_sq_ : delta_sq > threshold_sq_;
 }

--- a/src/receding_horizon_simulator.cpp
+++ b/src/receding_horizon_simulator.cpp
@@ -91,7 +91,7 @@ std::vector<std::shared_ptr<const SolverLog>> RecedingHorizonSimulator(
   while (true) {
     // Break the loop if it's been long enough.
     // Integrate a little more.
-    constexpr Time kExtraTime = 0.05;
+    constexpr Time kExtraTime = 0.25;
     t += kExtraTime;  // + planner_runtime;
 
     if (t >= final_time || !splicer.ContainsTime(t + planner_runtime +

--- a/src/roundabout_merging_example.cpp
+++ b/src/roundabout_merging_example.cpp
@@ -246,7 +246,7 @@ RoundaboutMergingExample::RoundaboutMergingExample(const SolverParams& params) {
   x0_(kP4VIdx) = kP4InitialSpeed;
 
   // Set up costs for all players.
-  PlayerCost p1_cost, p2_cost, p3_cost, p4_cost;
+  PlayerCost p1_cost("P1"), p2_cost("P2"), p3_cost("P3"), p4_cost("P4");
 
   // Stay in lanes.
   const std::shared_ptr<QuadraticPolyline2Cost> p1_lane_cost(

--- a/src/single_dimension_constraint.cpp
+++ b/src/single_dimension_constraint.cpp
@@ -51,14 +51,14 @@
 
 namespace ilqgames {
 
-bool SingleDimensionConstraint::IsSatisfied(const VectorXf& input,
-                                            float* level) const {
+bool SingleDimensionConstraint::IsSatisfiedLevel(const VectorXf& input,
+                                                 float* level) const {
   // Sign corresponding to the orientation of this constraint.
   const float sign = (oriented_right_) ? 1.0 : -1.0;
 
   // Maybe populate level.
   const float delta = threshold_ - input(dimension_);
-  if (level) *level = sign * delta;
+  *level = sign * delta;
 
   return (oriented_right_) ? delta < 0.0 : delta > 0.0;
 }

--- a/src/three_player_flat_intersection_example.cpp
+++ b/src/three_player_flat_intersection_example.cpp
@@ -224,7 +224,7 @@ ThreePlayerFlatIntersectionExample::ThreePlayerFlatIntersectionExample(
       kNumTimeSteps, dynamics_->NumPlayers(), 0.0, dynamics_));
 
   // Set up costs for all players.
-  PlayerCost p1_cost, p2_cost, p3_cost;
+  PlayerCost p1_cost("P1"), p2_cost("P2"), p3_cost("P3");
 
   // Stay in lanes.
   const Polyline2 lane1(

--- a/src/three_player_flat_overtaking_example.cpp
+++ b/src/three_player_flat_overtaking_example.cpp
@@ -213,7 +213,7 @@ ThreePlayerFlatOvertakingExample::ThreePlayerFlatOvertakingExample(
       kNumTimeSteps, dynamics_->NumPlayers(), 0.0, dynamics_));
 
   // Set up costs for all players.
-  PlayerCost p1_cost, p2_cost, p3_cost;
+  PlayerCost p1_cost("P1"), p2_cost("P2"), p3_cost("P3");
 
   // Orientation cost
   const std::shared_ptr<OrientationFlatCost> p1_nominal_heading(

--- a/src/three_player_intersection_example.cpp
+++ b/src/three_player_intersection_example.cpp
@@ -218,9 +218,9 @@ ThreePlayerIntersectionExample::ThreePlayerIntersectionExample(
       new OperatingPoint(kNumTimeSteps, dynamics->NumPlayers(), 0.0, dynamics));
 
   // Set up costs for all players.
-  PlayerCost p1_cost(kStateRegularization, kControlRegularization);
-  PlayerCost p2_cost(kStateRegularization, kControlRegularization);
-  PlayerCost p3_cost(kStateRegularization, kControlRegularization);
+  PlayerCost p1_cost("P1", kStateRegularization, kControlRegularization);
+  PlayerCost p2_cost("P2", kStateRegularization, kControlRegularization);
+  PlayerCost p3_cost("P3", kStateRegularization, kControlRegularization);
 
   // Stay in lanes.
   const Polyline2 lane1(

--- a/src/three_player_intersection_example.cpp
+++ b/src/three_player_intersection_example.cpp
@@ -93,18 +93,11 @@ static constexpr float kJerkCostWeight = 0.1;
 static constexpr float kMaxOmega = 1.0;
 
 static constexpr float kACostWeight = 0.1;
-static constexpr float kCurvatureCostWeight = 1.0;
-static constexpr float kMaxVCostWeight = 10.0;
 static constexpr float kNominalVCostWeight = 100.0;
 
-static constexpr float kGoalCostWeight = 0.1;
 static constexpr float kLaneCostWeight = 25.0;
-static constexpr float kLaneBoundaryCostWeight = 100.0;
 
 static constexpr float kMinProximity = 6.0;
-static constexpr float kP1ProximityCostWeight = 50.0;
-static constexpr float kP2ProximityCostWeight = 50.0;
-static constexpr float kP3ProximityCostWeight = 10.0;
 using ProxCost = ProximityCost;
 
 static constexpr bool kOrientedRight = true;
@@ -112,16 +105,6 @@ static constexpr bool kConstraintOrientedInside = false;
 
 // Lane width.
 static constexpr float kLaneHalfWidth = 2.5;  // m
-
-// Goal points.
-static constexpr float kP1GoalX = -6.0;   // m
-static constexpr float kP1GoalY = 600.0;  // m
-
-static constexpr float kP2GoalX = 500.0;  // m
-static constexpr float kP2GoalY = 12.0;   // m
-
-static constexpr float kP3GoalX = 100.0;  // m
-static constexpr float kP3GoalY = 16.0;   // m
 
 // Nominal and max speed.
 static constexpr float kP1MaxV = 12.0;  // m/s

--- a/src/three_player_overtaking_example.cpp
+++ b/src/three_player_overtaking_example.cpp
@@ -211,7 +211,7 @@ ThreePlayerOvertakingExample::ThreePlayerOvertakingExample(
       new OperatingPoint(kNumTimeSteps, dynamics->NumPlayers(), 0.0, dynamics));
 
   // Set up costs for all players.
-  PlayerCost p1_cost, p2_cost, p3_cost;
+  PlayerCost p1_cost("P1"), p2_cost("P2"), p3_cost("P3");
 
   // Orientation cost
   const auto p1_nominal_orientation_cost = std::make_shared<OrientationCost>(

--- a/src/two_player_collision_example.cpp
+++ b/src/two_player_collision_example.cpp
@@ -187,7 +187,7 @@ TwoPlayerCollisionExample::TwoPlayerCollisionExample(
       new OperatingPoint(kNumTimeSteps, dynamics->NumPlayers(), 0.0, dynamics));
 
   // Set up costs for all players.
-  PlayerCost p1_cost, p2_cost;
+  PlayerCost p1_cost("P1"), p2_cost("P2");
 
   // Orientation cost
   const auto p1_nominal_orientation_cost = std::make_shared<OrientationCost>(


### PR DESCRIPTION
Implements a bit of a dirty but intuitive fix for initial guesses not being feasible. Now each constraint must specify an "equivalent cost" which is used whenever the trajectory specified by the operating point and strategies is not feasible. The idea is that if this "equivalent cost" version is used enough then the constraints should eventually be satisfied, though of course that's only a heuristic. Other fixes could work if the constraints did not change between solver calls, but that's not very realistic so I didn't want to depend on that. This fix seems to work for the receding horizon example, which now runs very quickly (<10ms / instantiation).