### PR TITLE
trying new merit function + linesearch

### DIFF
--- a/include/ilqgames/cost/player_cost.h
+++ b/include/ilqgames/cost/player_cost.h
@@ -86,6 +86,7 @@ class PlayerCost {
   float Evaluate(Time t, const VectorXf& x,
                  const std::vector<VectorXf>& us) const;
   float Evaluate(const OperatingPoint& op, Time time_step) const;
+  float Evaluate(const OperatingPoint& op) const;
   float EvaluateOffset(Time t, Time next_t, const VectorXf& next_x,
                        const std::vector<VectorXf>& us) const;
 

--- a/src/player_cost.cpp
+++ b/src/player_cost.cpp
@@ -165,6 +165,13 @@ float PlayerCost::Evaluate(const OperatingPoint& op, Time time_step) const {
   return cost;
 }
 
+float PlayerCost::Evaluate(const OperatingPoint& op) const {
+  float total_cost = 0.0;
+  for (size_t kk = 0; kk < op.xs.size(); kk++) total_cost += Evaluate(op, kk);
+
+  return total_cost;
+}
+
 float PlayerCost::EvaluateOffset(Time t, Time next_t, const VectorXf& next_x,
                                  const std::vector<VectorXf>& us) const {
   float total_cost = 0.0;


### PR DESCRIPTION
This is based on #45, where as discussed in #45 I noticed that maybe we can get away without costates in the merit function/linesearch. This basically amounts to using the sum of all players' objectives as a merit function. Clearly, local minimizers of this function include local minimizers of each individual players' objective, but not the other way around. If this works well, it indicates that we are still descending on this "more general" merit function. The benefit of using it is that it does not require costates.

Empirically, this new merit function + linesearch works at least as well as the previous method. At some point, we should try to incorporate costates but for now this is probably simplest.