### PR TITLE
Add support for solver resetting problem and constraints

### DIFF
--- a/include/ilqgames/constraint/constraint.h
+++ b/include/ilqgames/constraint/constraint.h
@@ -120,7 +120,7 @@ class Constraint : public Cost {
   explicit Constraint(bool is_equality, const std::string& name)
       : Cost(1.0, name),
         is_equality_(is_equality),
-        lambdas_(time::kNumTimeSteps, 0.0) {}
+        lambdas_(time::kNumTimeSteps, constants::kDefaultLambda) {}
 
   // Modify derivatives to account for the multipliers and the quadratic term in
   // the augmented Lagrangian. The inputs are the derivatives of g in the

--- a/include/ilqgames/solver/solver_params.h
+++ b/include/ilqgames/solver/solver_params.h
@@ -75,6 +75,12 @@ struct SolverParams {
   float geometric_mu_downscaling = 0.5;
   float geometric_lambda_downscaling = 0.5;
   float constraint_error_tolerance = 1e-1;
+
+  // Should the solver reset problem/constraint params to their initial values.
+  // NOTE: defaults to true.
+  bool reset_problem = true;
+  bool reset_lambdas = true;
+  bool reset_mu = true;
 };  // struct SolverParams
 
 }  // namespace ilqgames

--- a/include/ilqgames/utils/solver_log.h
+++ b/include/ilqgames/utils/solver_log.h
@@ -164,7 +164,8 @@ class SolverLog : private Uncopyable {
   // Get index corresponding to the time step immediately before the given time.
   size_t TimeToIndex(Time t) const {
     return static_cast<size_t>(
-        std::max(constants::kSmallNumber, t - InitialTime()) / time::kTimeStep);
+        std::max<Time>(constants::kSmallNumber, t - InitialTime()) /
+        time::kTimeStep);
   }
 
   // Get time stamp corresponding to a particular index.

--- a/include/ilqgames/utils/types.h
+++ b/include/ilqgames/utils/types.h
@@ -111,7 +111,7 @@ struct Empty {};
 // ------------------------------- CONSTANTS -------------------------------- //
 
 namespace constants {
-#ifdef __APPLE__
+
 // Acceleration due to gravity (m/s/s).
 static constexpr float kGravity = 9.81;
 
@@ -124,19 +124,10 @@ static constexpr float kInfinity = std::numeric_limits<float>::infinity();
 // Constant for invalid values.
 static constexpr float kInvalidValue = std::numeric_limits<float>::quiet_NaN();
 
-#else
-// Acceleration due to gravity (m/s/s).
-static constexpr double kGravity = 9.81;
+// Default multiplier values.
+static constexpr float kDefaultLambda = 0.0;
+static constexpr float kDefaultMu = 10.0;
 
-// Small number for use in approximate equality checking.
-static constexpr double kSmallNumber = 1e-4;
-
-// Float precision infinity.
-static constexpr double kInfinity = std::numeric_limits<float>::infinity();
-
-// Constant for invalid values.
-static constexpr double kInvalidValue = std::numeric_limits<float>::quiet_NaN();
-#endif
 }  // namespace constants
 
 namespace time {

--- a/src/augmented_lagrangian_solver.cpp
+++ b/src/augmented_lagrangian_solver.cpp
@@ -73,6 +73,10 @@ std::shared_ptr<SolverLog> AugmentedLagrangianSolver::Solve(bool* success,
                                                             Time max_runtime) {
   if (success) *success = true;
 
+  // Cache initial problem solution so we can restore it at the end.
+  const auto& initial_op = problem_->CurrentOperatingPoint();
+  const auto& initial_strategies = problem_->CurrentStrategies();
+
   // Create new log.
   std::shared_ptr<SolverLog> log = CreateNewLog();
 
@@ -186,9 +190,12 @@ std::shared_ptr<SolverLog> AugmentedLagrangianSolver::Solve(bool* success,
     if (success) *success = false;
   }
 
+  // Restore initial solution to this problem.
+  problem_->OverwriteSolution(initial_op, initial_strategies);
+
   // Update problem solution to make sure we get the final log output.
-  problem_->OverwriteSolution(log->FinalOperatingPoint(),
-                              log->FinalStrategies());
+  // problem_->OverwriteSolution(log->FinalOperatingPoint(),
+  //                             log->FinalStrategies());
 
   return log;
 }

--- a/src/augmented_lagrangian_solver.cpp
+++ b/src/augmented_lagrangian_solver.cpp
@@ -190,22 +190,21 @@ std::shared_ptr<SolverLog> AugmentedLagrangianSolver::Solve(bool* success,
     if (success) *success = false;
   }
 
-  // Restore initial solution to this problem.
-  problem_->OverwriteSolution(initial_op, initial_strategies);
+  // Maybe restore initial solution to this problem.
+  if (params_.reset_problem)
+    problem_->OverwriteSolution(initial_op, initial_strategies);
 
   // Reset all multipliers.
-  for (auto& pc : problem_->PlayerCosts()) {
-    for (const auto& constraint : pc.StateConstraints())
-      constraint->ScaleLambdas(0.0);
-    for (const auto& pair : pc.ControlConstraints())
-      pair.second->ScaleLambdas(0.0);
+  if (params_.reset_lambdas) {
+    for (auto& pc : problem_->PlayerCosts()) {
+      for (const auto& constraint : pc.StateConstraints())
+        constraint->ScaleLambdas(constants::kDefaultLambda);
+      for (const auto& pair : pc.ControlConstraints())
+        pair.second->ScaleLambdas(constants::kDefaultLambda);
+    }
   }
 
-  Constraint::GlobalMu() = 10.0;
-
-  // Update problem solution to make sure we get the final log output.
-  // problem_->OverwriteSolution(log->FinalOperatingPoint(),
-  //                             log->FinalStrategies());
+  if (params_.reset_mu) Constraint::GlobalMu() = constants::kDefaultMu;
 
   return log;
 }

--- a/src/augmented_lagrangian_solver.cpp
+++ b/src/augmented_lagrangian_solver.cpp
@@ -196,12 +196,12 @@ std::shared_ptr<SolverLog> AugmentedLagrangianSolver::Solve(bool* success,
   // Reset all multipliers.
   for (auto& pc : problem_->PlayerCosts()) {
     for (const auto& constraint : pc.StateConstraints())
-      constraint->Lambda() = 0.0;
+      constraint->ScaleLambdas(0.0);
     for (const auto& pair : pc.ControlConstraints())
-      pair.second->Lambda() = 0.0;
+      pair.second->ScaleLambdas(0.0);
   }
 
-  Constraint::GlobalMu() = 1.0;
+  Constraint::GlobalMu() = 10.0;
 
   // Update problem solution to make sure we get the final log output.
   // problem_->OverwriteSolution(log->FinalOperatingPoint(),

--- a/src/augmented_lagrangian_solver.cpp
+++ b/src/augmented_lagrangian_solver.cpp
@@ -193,6 +193,16 @@ std::shared_ptr<SolverLog> AugmentedLagrangianSolver::Solve(bool* success,
   // Restore initial solution to this problem.
   problem_->OverwriteSolution(initial_op, initial_strategies);
 
+  // Reset all multipliers.
+  for (auto& pc : problem_->PlayerCosts()) {
+    for (const auto& constraint : pc.StateConstraints())
+      constraint->Lambda() = 0.0;
+    for (const auto& pair : pc.ControlConstraints())
+      pair.second->Lambda() = 0.0;
+  }
+
+  Constraint::GlobalMu() = 1.0;
+
   // Update problem solution to make sure we get the final log output.
   // problem_->OverwriteSolution(log->FinalOperatingPoint(),
   //                             log->FinalStrategies());

--- a/src/constraint.cpp
+++ b/src/constraint.cpp
@@ -58,7 +58,7 @@
 
 namespace ilqgames {
 
-float Constraint::mu_ = 10.0;
+float Constraint::mu_ = constants::kDefaultMu;
 
 void Constraint::ModifyDerivatives(Time t, float g, float* dx, float* ddx,
                                    float* dy, float* ddy, float* dxdy) const {


### PR DESCRIPTION
It can be convenient to make sure a solver does not affect the solution to a problem or any constraint multipliers (i.e., that it resets them to their initial values upon termination). This is necessary, e.g., when multiple problems are solved in a receding horizon or to overlay in the GUI.