### PR TITLE
Adaptive regularization in feedback LQ

### DIFF
--- a/include/ilqgames/solver/lq_feedback_solver.h
+++ b/include/ilqgames/solver/lq_feedback_solver.h
@@ -72,11 +72,12 @@ class LQFeedbackSolver : public LQSolver {
   ~LQFeedbackSolver() {}
   LQFeedbackSolver(
       const std::shared_ptr<const MultiPlayerIntegrableSystem>& dynamics,
-      size_t num_time_steps)
-      : LQSolver(dynamics, num_time_steps) {
+      size_t num_time_steps, bool adaptive_regularization = true)
+      : LQSolver(dynamics, num_time_steps),
+        adaptive_regularization_(adaptive_regularization) {
     // Cache the total number of control dimensions, since this is inefficient
     // to compute.
-    const Dimension total_udim = dynamics_->TotalUDim();
+    const Dimension total_udim = dynamics_->TotalUDim();  // 2
 
     // Preallocate memory for coupled Riccati solve at each time step and make
     // Eigen::Refs to the solution.
@@ -140,6 +141,9 @@ class LQFeedbackSolver : public LQSolver {
   // Preallocate memory for intermediate variables F, beta.
   MatrixXf F_;
   VectorXf beta_;
+
+  // Adaptive regularization using Gershgorin circle theorem.
+  const bool adaptive_regularization_;
 };  // LQFeedbackSolver
 
 }  // namespace ilqgames

--- a/src/lq_feedback_solver.cpp
+++ b/src/lq_feedback_solver.cpp
@@ -160,6 +160,17 @@ std::vector<Strategy> LQFeedbackSolver::Solve(
       cumulative_udim_row += dynamics_->UDim(ii);
     }
 
+    // Regularize `S` to have positive eigenvalues using the Gershgorin circle
+    // theorem (https://en.wikipedia.org/wiki/Gershgorin_circle_theorem). That
+    // is, for column i, compute the 1-norm of non-diagonal entries and ensure
+    // that the ii^th entry of `S` is greater than that norm by adding some
+    // amount to that diagonal entry.
+    for (size_t ii = 0; ii < S_.cols(); ii++) {
+      const float eval_lo =
+          S_(ii, ii) + std::abs(S_(ii, ii)) - S_.col(ii).lpNorm<1>();
+      S_(ii, ii) -= std::min(0.0f, eval_lo);
+    }
+
     // Solve linear matrix equality S X = Y.
     // NOTE: not 100% sure that this avoids dynamic memory allocation.
     X_ = S_.householderQr().solve(Y_);


### PR DESCRIPTION
In the feedback LQ Nash solver, this adds an amount to each diagonal element to the big `S` matrix in the coupled Ricatti equation which is just enough to ensure that all eigenvalues are nonnegative. This amount is computed according to the Gershgorin Circle Theorem: https://en.wikipedia.org/wiki/Gershgorin_circle_theorem

@lassepe this is what I had in mind. Does this match what you were thinking? 